### PR TITLE
[REFACTOR] 엔티티 필드명 및 제약조건 통일

### DIFF
--- a/src/main/java/mju/library/domain/lending/Lending.java
+++ b/src/main/java/mju/library/domain/lending/Lending.java
@@ -20,7 +20,7 @@ public class Lending extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long Id;
+    private Long id; // Id → id (일관성 통일)
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)

--- a/src/main/java/mju/library/domain/like/LikeBook.java
+++ b/src/main/java/mju/library/domain/like/LikeBook.java
@@ -11,6 +11,10 @@ import mju.library.domain.member.Member;
 
 
 @Entity
+@Table(
+        name = "like_book",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"member_id", "book_id"}) // 중복 방지 제약 추가
+)
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/mju/library/domain/reservation/Reservation.java
+++ b/src/main/java/mju/library/domain/reservation/Reservation.java
@@ -20,7 +20,7 @@ import java.time.LocalDateTime;
 public class Reservation extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long Id;
+    private Long id; // Id → id (일관성 통일)
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
@@ -30,6 +30,7 @@ public class Reservation extends BaseEntity {
     @JoinColumn(name = "book_id", nullable = false)
     private Book book;
 
+    @Column(nullable = false) // 필수 제약 추가
     private LocalDateTime reservationDate;
 
 }

--- a/src/main/java/mju/library/domain/review/Review.java
+++ b/src/main/java/mju/library/domain/review/Review.java
@@ -29,6 +29,6 @@ public class Review extends BaseEntity {
     @JoinColumn(name = "book_id", nullable = false)
     private Book book;
 
-    @Column(length = 2000)
+    @Column(nullable = false, length = 2000) // 필수 제약 추가
     private String reviewText;
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,7 +10,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update # create # TODO: 추후에 classnet mysql로 바꾼다면 none으로 변경
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
### 📌 개요
엔티티 구조의 일관성과 데이터 무결성을 강화하기 위해
다음과 같은 리팩토링을 수행했습니다.

변경점 | 이유
-- | --
Id → id | 자바 필드 네이밍 일관성 (camelCase) 유지
@UniqueConstraint 추가 | LikeBook 중복 방지
@Column(nullable=false) | 데이터 유효성 보장


---

### ✨ 수정 내용
1. **필드명 통일**
   - 기존 `Id` → `id` (소문자 통일)
   - 대상: Lending, Reservation, Review, LikeBook

2. **중복 방지 제약 추가**
   - `LikeBook` 테이블에 `@UniqueConstraint(member_id, book_id)` 추가
   - 동일한 회원이 동일한 책을 중복 찜할 수 없도록 설정

3. **필수 컬럼 제약 명시**
   - `@Column(nullable=false)` 추가
   - 대상: `Lending.lendDate`, `Lending.dueDate`, `Lending.status`,
            `Reservation.reservationDate`, `Review.reviewText`

---

### 🔍 기대 효과
- 필드 네이밍 컨벤션 통일로 코드 가독성 향상
- LikeBook 중복 데이터 방지로 무결성 확보
- 주요 데이터의 null 입력 방지로 데이터 품질 개선

